### PR TITLE
Add tool-advisor to Reference Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Guides and tools for authoring, validating, and distributing skills.
 
 #### Development and Programming
 
+- [dragon1086/claude-skills](https://github.com/dragon1086/claude-skills) - Tool Advisor: Analyzes prompts and recommends optimal tools, skills, and orchestration patterns.
 - [kylehughes/the-unofficial-swift-concurrency-migration-skill](https://github.com/kylehughes/the-unofficial-swift-concurrency-migration-skill) - Skill-style guide for Swift concurrency migrations.
 - [gapmiss/obsidian-plugin-skill](https://github.com/gapmiss/obsidian-plugin-skill) - Skill package for Obsidian plugin development.
 - [frmoretto/stream-coding](https://github.com/frmoretto/stream-coding) - Stream-coding methodology reference.


### PR DESCRIPTION
## Summary

Adding [tool-advisor](https://github.com/dragon1086/claude-skills) to **Reference Implementations → Development and Programming**.

### What is tool-advisor?

A skill that analyzes prompts and recommends optimal tools, skills, and orchestration patterns.

**Features:**
- Checks local inventory first (plugins, skills, agents, MCP servers)
- Assesses task complexity (Simple/Medium/Complex/Long-running)
- Recommends harness patterns for complex tasks (Ralph, RIPER, etc.)
- Provides copy-paste Quick Action commands
- Suggests installation when tools are missing

**Install:**
```bash
npx skills add dragon1086/claude-skills -y --agent claude-code
```

### Checklist
- [x] Follows format: `[Title](URL) - Description`
- [x] Link verified
- [x] No duplicates
- [x] Relevant to Agent Skills (SKILL.md format)