### PR TITLE
Add Transloadit skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [gotalab/skillport](https://github.com/gotalab/skillport) - CLI and MCP-based skill distribution.
 - [gmickel/sheets-cli](https://github.com/gmickel/sheets-cli) - Google Sheets automation via CLI.
 - [fabioc-aloha/spotify-skill](https://github.com/fabioc-aloha/spotify-skill) - Spotify API integration skill.
+- [transloadit/skills](https://github.com/transloadit/skills) - Media processing skills: video encoding, image generation, OCR, and 86+ Robots.
 
 ## Phase 4: Benchmarks and Research
 


### PR DESCRIPTION
Adds [transloadit/skills](https://github.com/transloadit/skills) to the Integration and Automation section under Reference Implementations.

6 agent skills for media processing — video encoding, image generation, document conversion, OCR, and more via 86+ Robots. All follow the Agent Skills open standard with SKILL.md frontmatter.

**Docs:** [transloadit.com/docs/sdks/mcp-server](https://transloadit.com/docs/sdks/mcp-server/)