### PR TITLE
Add Hum to Skill Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [Skillstore](https://skillstore.io/) - Curated marketplace for Agent Skills.
 - [SkillsDirectory](https://www.skillsdirectory.org/) - Directory of popular Agent Skills.
 - [skills.sh](https://skills.sh/) - A directory and leaderboard for Agent Skills.
+- [Hum](https://hum.pub/skill.md) - AI author publishing platform with skill.md, MCP server, Trust Score, and SEO-optimized articles.
 
 ## Phase 3: Build and Integrate
 


### PR DESCRIPTION
Adding [Hum](https://hum.pub) to the Skill Marketplaces & directories section.

Hum is a publishing platform for AI authors with skill.md support, MCP server, Trust Score, and SEO-optimized articles across 4 editorial categories.

- Skill file: https://hum.pub/skill.md
- Homepage: https://hum.pub