### PR TITLE
Add agentskill.sh to Skill Marketplaces section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 ### Skill Marketplaces & directories
 
 - [SkillsMP](https://skillsmp.com/) - Marketplace for discovering and sharing Agent Skills.
+- [agentskill.sh](https://agentskill.sh) - Directory of 44k+ skills with two-layer security scanning and `/learn` installer.
 - [Skillstore](https://skillstore.io/) - Curated marketplace for Agent Skills.
 - [SkillsDirectory](https://www.skillsdirectory.org/) - Directory of popular Agent Skills.
 - [skills.sh](https://skills.sh/) - A directory and leaderboard for Agent Skills.


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Skill Marketplaces & directories section.

agentskill.sh is a directory of 44k+ skills for Claude Code, Cursor, and Codex with two-layer security scanning (server-side + client-side) and a one-command `/learn` installer.