### PR TITLE
Add product-on-purpose/pm-skills to More Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Pydantic AI integration skills.
 - [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) - Skills for DSPy-based workflows.
 - [ponderous-dustiness314/awesome-claude-skills](https://github.com/ponderous-dustiness314/awesome-claude-skills) - Document editing, data analysis, and project management skills.
+- [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 plug-and-play product management skills for the full delivery lifecycle.
 - [hikanner/agent-skills](https://github.com/hikanner/agent-skills) - Curated Agent Skills collection.
 - [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) - Freeact skill library.
 


### PR DESCRIPTION
## Summary

- Adds [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) to the **More Collections** section
- 24 plug-and-play product management skills following the [agentskills.io specification](https://agentskills.io/specification), covering the full PM delivery lifecycle across 6 Triple Diamond phases
- Entry inserted in alphabetical order (between `ponderous-dustiness314` and `shajith003`)

## Why this fits

pm-skills is a curated skill library built on the agentskills.io spec with standardized `SKILL.md` packages for product management workflows — discovery, definition, design, development, delivery, and distribution. Apache 2.0 licensed and actively maintained.

## Checklist

- [x] Entry follows the existing `[owner/repo](url) - Description.` format
- [x] Alphabetical placement within the section
- [x] Link is valid and repo is public
- [x] Description is concise and ends with a period