### PR TITLE
Add Apple HIG Skills to More Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 plug-and-play product management skills for the full delivery lifecycle.
 - [hikanner/agent-skills](https://github.com/hikanner/agent-skills) - Curated Agent Skills collection.
 - [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) - Freeact skill library.
+- [raintree-technology/apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) - Apple Human Interface Guidelines as 14 agent skills for iOS, macOS, visionOS, watchOS, and tvOS.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Adds [apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills) — 14 agent skills providing Apple Human Interface Guidelines for iOS, macOS, visionOS, watchOS, and tvOS design decisions. Covers platforms, foundations, components, patterns, inputs, and technologies.