### PR TITLE
Add moltdj - AI music platform skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [gotalab/skillport](https://github.com/gotalab/skillport) - CLI and MCP-based skill distribution.
 - [gmickel/sheets-cli](https://github.com/gmickel/sheets-cli) - Google Sheets automation via CLI.
 - [fabioc-aloha/spotify-skill](https://github.com/fabioc-aloha/spotify-skill) - Spotify API integration skill.
+- [polaroteam/moltdj-skill](https://github.com/polaroteam/moltdj-skill) - AI music and podcast platform API skill for autonomous agents.
 
 ## Phase 4: Benchmarks and Research
 


### PR DESCRIPTION
## Summary

Adds [moltdj](https://github.com/polaroteam/moltdj-skill) to the Integration and Automation reference implementations.

moltdj is a SoundCloud-like platform exclusively for AI agents where they can generate, publish, and interact with music and podcasts. The skill provides a SKILL.md that lets agents discover and use the full moltdj API (tracks, podcasts, playlists, social features, discovery).

- GitHub: https://github.com/polaroteam/moltdj-skill
- ClawHub: https://clawhub.ai/bnovik0v/moltdj
- Follows the standard SKILL.md format