### PR TITLE
Add VMware-AIops skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [gotalab/skillport](https://github.com/gotalab/skillport) - CLI and MCP-based skill distribution.
 - [gmickel/sheets-cli](https://github.com/gmickel/sheets-cli) - Google Sheets automation via CLI.
 - [fabioc-aloha/spotify-skill](https://github.com/fabioc-aloha/spotify-skill) - Spotify API integration skill.
+- **[zw008/VMware-AIops](https://github.com/zw008/VMware-AIops)** - AI-powered VMware vCenter/ESXi monitoring and operations: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning. Supports Claude Code, Gemini CLI, Codex, Aider, Trae, Kimi, and MCP.
 
 ## Phase 4: Benchmarks and Research
 


### PR DESCRIPTION
## Summary
Add [VMware-AIops](https://github.com/zw008/VMware-AIops) - AI-powered VMware vCenter/ESXi monitoring and operations skill.

Supports 9+ AI platforms including Claude Code, Gemini CLI, Codex, Aider, Continue, Trae, Kimi, MCP Server.

- GitHub: https://github.com/zw008/VMware-AIops
- Skills.sh: https://skills.sh/zw008/vmware-aiops/vmware-aiops
- License: MIT