### PR TITLE
Add agent-tutor-skill to Reference Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Guides and tools for authoring, validating, and distributing skills.
 - [gmickel/sheets-cli](https://github.com/gmickel/sheets-cli) - Google Sheets automation via CLI.
 - [fabioc-aloha/spotify-skill](https://github.com/fabioc-aloha/spotify-skill) - Spotify API integration skill.
 
+#### Education and Learning
+
+- [Bhala-Srinivash/agent-tutor-skill](https://github.com/Bhala-Srinivash/agent-tutor-skill) - Cognitive science AI tutor with teaching loop, FSRS spaced repetition, and zero-hint quizzes.
+
 ## Phase 4: Benchmarks and Research
 
 Evaluation frameworks and deeper technical reading.


### PR DESCRIPTION
## Summary
- Adds [agent-tutor-skill](https://github.com/Bhala-Srinivash/agent-tutor-skill) under a new **Education and Learning** subsection in Reference Implementations
- Cognitive science-based AI tutor skill implementing:
  - Teaching loop (Explain→Example→Check→Evaluate→Practice)
  - FSRS spaced repetition (adaptive intervals per concept)
  - Zero-hint quizzes with concept-level mastery tracking
  - Source-aware teaching from PDFs, docs, code, and URLs
  - Learning profile diagnostics

## Why this belongs here
This is the first education/learning-focused skill in the directory. It's built on cognitive science research (Roediger & Karpicke, Robert Bjork, Ebbinghaus) and inspired by [Mia Kiraki's AI tutor framework](https://robotsatemyhomework.substack.com/p/the-ai-tutor-i-built-in-claude-that).

Installable via `npx skills add Bhala-Srinivash/agent-tutor-skill`.