### PR TITLE
Add product-manager-skills to skill collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [ponderous-dustiness314/awesome-claude-skills](https://github.com/ponderous-dustiness314/awesome-claude-skills) - Document editing, data analysis, and project management skills.
 - [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 plug-and-play product management skills for the full delivery lifecycle.
 - [hikanner/agent-skills](https://github.com/hikanner/agent-skills) - Curated Agent Skills collection.
+- [Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks for discovery, strategy, delivery, SaaS metrics, PM career coaching, and AI product craft.
 - [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) - Freeact skill library.
 
 ### Skill Marketplaces & directories


### PR DESCRIPTION
## Summary

- Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the "More Collections" section under Ready-to-Use Skill Libraries
- Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks

## Details

This skill package provides comprehensive product management capabilities:
- Product discovery and strategy frameworks
- Delivery and execution templates
- 32 SaaS metrics with formulas
- PM career coaching from IC to CPO level
- AI product craft guidance

Follows the existing list format used in the More Collections section.

GitHub: https://github.com/Digidai/product-manager-skills
ClawHub: https://clawhub.ai/Digidai/product-manager-skills