### PR TITLE
Add skill: readtheskill/readtheskill

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [readtheskill/readtheskill](https://github.com/readtheskill/readtheskill) - AI agent skill propagation experiment on Solana with live tracking
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Adds [readtheskill](https://github.com/readtheskill/readtheskill) to Popular Collections.

Open-source AI agent skill propagation experiment on Solana with live discovery tracking at [readtheskill.com](https://readtheskill.com).