### PR TITLE
Add ClawAudit — security auditor for Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [Skillstore](https://skillstore.io/) - Curated marketplace for Agent Skills.
 - [SkillsDirectory](https://www.skillsdirectory.org/) - Directory of popular Agent Skills.
 - [skills.sh](https://skills.sh/) - A directory and leaderboard for Agent Skills.
+- [ClawAudit](https://clauwdit.4worlds.dev) - Security auditor for Agent Skills. Static analysis of SKILL.md files for prompt injection, credential exfiltration, and dangerous capabilities. Scanned all 19,461 OpenClaw skills.
 
 ## Phase 3: Build and Integrate
 


### PR DESCRIPTION
Adds [ClawAudit](https://clauwdit.4worlds.dev) to the Skill Marketplaces & directories section.

ClawAudit is a security auditor for Agent Skills. It performs static analysis on SKILL.md files to detect prompt injection, credential exfiltration, obfuscated payloads, and dangerous capability combinations.

We scanned all 19,461 OpenClaw skills, [full report](https://clauwdit.4worlds.dev/report). Free API, no auth required.