### PR TITLE
Add TypeUI to the list of tools and frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [LangChain Deep Agents](https://github.com/langchain-ai/deepagents) - Framework: Agent harness with a skills-oriented workflow.
 - [IntentKit](https://github.com/crestalnetwork/intentkit) - Framework: Intent-driven agent building.
 - [Agentica](https://github.com/wrtnlabs/agentica) - Framework: TypeScript function-calling utilities for agents.
+- [TypeUI](https://github.com/bergside/typeui.sh) - Open-source CLI tool to generate skill files for design systems
 
 ### Reference Implementations
 


### PR DESCRIPTION
Hey @xxl007,

I released today an open-source cli called [typeui.sh](https://github.com/bergside/typeui.sh) that generates skill files for design system specifications - basically to make websites look a certain way when AI's build them.

Hope you think we can add it :)