### PR TITLE
docs: add Nutrient document processing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [Supabase skills](https://github.com/supabase/agent-skills) - Agent Skills to help developers using AI agents with Supabase.
 - [Hugging Face skills](https://github.com/huggingface/skills) - Community skills catalog with broad compatibility.
 - [OpenClaw skills](https://www.clawhub.ai/skills) - Skills for OpenClow agents (formerly Clawd and Moltbot).
+- [Nutrient document processing skills](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Production-grade document processing skills powered by Nutrient DWS: convert PDF/Office/images, OCR, extract text/tables/key-values, redact PII (pattern+AI), watermark, sign, merge/split/reorder pages, and form fill.
 
 #### Popular Collections
 


### PR DESCRIPTION
Adds Nutrient Document Processing skills to Top Picks.

Repo: https://github.com/PSPDFKit-labs/nutrient-agent-skill

This description now reflects full document processing capabilities, not only HTML→PDF:
- Conversion (DOCX/XLSX/PPTX/HTML/image ↔ PDF)
- OCR and text/table/key-value extraction
- Redaction (pattern-based + AI)
- Watermarking and digital signatures
- Image rendering, office conversion, and credits/usage checks
