### PR TITLE
docs: add NoizAI/skills to Popular Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [NoizAI/skills](https://github.com/NoizAI/skills) - Human-like TTS skills with style control, local/cloud backends, and app-ready voice workflows.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Hi maintainers, thanks for curating this list.

I'd like to add [NoizAI/skills](https://github.com/NoizAI/skills) under **Popular Collections** — a practical skill collection for human-like TTS workflows.

Why it fits here:
- Validated guidance for more human-like speech (fillers, emotional tone, speaking presets).
- End-to-end workflow: generate voice and route to real delivery channels (chat apps, broadcasting).
- Developer-friendly local + cloud backend options, free to start.

Quick try:
- `npx skills add NoizAI/skills --list --full-depth`
- `npx skills add NoizAI/skills --full-depth --skill tts -y`

Evidence:
- Star trend: https://www.star-history.com/#NoizAI/skills&Date
- Demos: https://github.com/NoizAI/skills#english-audio-demos

Happy to adjust wording to match your preferred format.

Made with [Cursor](https://cursor.com)