### PR TITLE
Add Prism Scanner CI workflow for security scanning

### DIFF
--- a/.github/workflows/prism-scan.yml
+++ b/.github/workflows/prism-scan.yml
@@ -1,0 +1,22 @@
+name: Prism Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aidongise-cell/prism-scanner@main
+        with:
+          path: "."
+          fail-on: "high"
+


### PR DESCRIPTION
## Summary

Adds a [Prism Scanner](https://github.com/aidongise-cell/prism-scanner) security scan to CI.

**Why:** This repo curates agent skills — automatically scanning for security risks protects users who install skills listed here.

**What it does:**
- Runs on every push/PR to main
- Scans all code with 39+ detection rules (AST taint tracking, malicious signatures, metadata analysis)
- Uploads SARIF results to GitHub Code Scanning (Security tab)
- Fails CI on HIGH or CRITICAL findings

**Zero config required** — the workflow installs `prism-scanner` via pip and runs automatically.