### PR TITLE
Add skill_miner to Developer Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [LangChain Deep Agents](https://github.com/langchain-ai/deepagents) - Framework: Agent harness with a skills-oriented workflow.
 - [IntentKit](https://github.com/crestalnetwork/intentkit) - Framework: Intent-driven agent building.
 - [Agentica](https://github.com/wrtnlabs/agentica) - Framework: TypeScript function-calling utilities for agents.
+- [skill_miner](https://github.com/liaoandi/skill_miner) - Tool: Mine reusable skills from AI agent session history by analyzing sessions across Claude Code, Codex, OpenClaw, and Gemini CLI.
 
 ### Reference Implementations
 


### PR DESCRIPTION
## What

Adds [skill_miner](https://github.com/liaoandi/skill_miner) to the **Developer Tools** section.

## About skill_miner

- Scans AI agent session history (Claude Code, Codex, OpenClaw, Gemini CLI) to discover recurring workflows
- Uses LLM to extract, classify, and deduplicate skill candidates
- Generates ready-to-use SKILL.md files from accepted candidates
- Available on [PyPI](https://pypi.org/project/skill-miner/): `pip install skill-miner[anthropic]`