### PR TITLE
Add datadog-observability to Integration and Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [gotalab/skillport](https://github.com/gotalab/skillport) - CLI and MCP-based skill distribution.
 - [gmickel/sheets-cli](https://github.com/gmickel/sheets-cli) - Google Sheets automation via CLI.
 - [fabioc-aloha/spotify-skill](https://github.com/fabioc-aloha/spotify-skill) - Spotify API integration skill.
+- [Ivlad003/plugins](https://github.com/Ivlad003/plugins) - Query and analyze Datadog logs, metrics, monitors, and traces directly from Claude Code via REST API.
 
 ## Phase 4: Benchmarks and Research
 


### PR DESCRIPTION
## Summary
- Adds [datadog-observability](https://github.com/Ivlad003/plugins) to the **Integration and Automation** section
- Query and analyze Datadog logs, metrics, monitors, and traces directly from Claude Code via REST API

## Details
- 5 slash commands: `/dd-logs`, `/dd-query`, `/dd-alerts`, `/dd-status`, `/dd-investigate`
- Auto-activated `datadog-ops` skill with 12 API operations
- `datadog-investigator` agent for incident root cause analysis
- Uses curl directly — no MCP server or extra dependencies
- MIT licensed, public repo, tested and working

Closes #41