### PR TITLE
Add hnaymyh123-henry/claude-dev-skill to Popular Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [hnaymyh123-henry/claude-dev-skill](https://github.com/hnaymyh123-henry/claude-dev-skill) - A Claude Code skill that turns Claude into a Tech Lead, orchestrating parallel Worker Agents through a full dev workflow: PRD alignment, architecture, coding, QA, and PR review.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
## Description

Adding `claude-dev-skill` to the **Popular Collections** section under Phase 2.

## Skill Details

- **Repository:** https://github.com/hnaymyh123-henry/claude-dev-skill
- **Description:** A Claude Code skill that turns Claude into a Tech Lead, orchestrating parallel Worker Agents through a full dev workflow: PRD alignment, architecture, coding, QA, and PR review.

## Why it fits

This skill showcases a practical multi-agent development workflow pattern using Claude Code's SKILL.md system — relevant to readers learning how to use and build Agent Skills in Phase 2 of this guide.

## Checklist

- [x] Public repository with proper SKILL.md
- [x] Follows existing bullet format
- [x] No duplicates
- [x] Relevant to Agent Skills ecosystem