### PR TITLE
feat: add enterprise-agent-skills — .NET, Laravel, Java, SQL Server skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [iamBrzDev/enterprise-agent-skills](https://github.com/iamBrzDev/enterprise-agent-skills) - Production-grade Agent Skills for the enterprise backend stack: .NET Clean Architecture, Laravel, Java Spring Boot, SQL Server, Azure DevOps pipelines, and testing patterns.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Adds iamBrzDev/enterprise-agent-skills to the Popular Collections section.

8 production-grade skills for the enterprise backend stack that had no
coverage in the Agent Skills ecosystem:
- dotnet-clean-architecture, laravel-enterprise, sqlserver-query-patterns
- enterprise-pr-review, azure-devops-pipelines, java-spring-enterprise  
- dotnet-testing, laravel-cicd

Published at skills.sh/iambrzdev/enterprise-agent-skills
Tested with Claude Code and Cursor.