### PR TITLE
Add oconsole/odoo-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [oconsole/odoo-skills](https://github.com/oconsole/odoo-skills) - Seven Odoo ERP skills for model inspection, accounting, manufacturing, inventory, system health, and runtime customization.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
## Summary
- Add oconsole/odoo-skills to the Popular Collections section
- 7 Odoo ERP skills (5 read-only inspection + 2 runtime customization)
- Verified on Odoo 18 and 19, MIT licensed
- Auto-curated pitfall lists via RL pipeline
- Source: https://github.com/oconsole/odoo-skills