### PR TITLE
Add fabbo-ai-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [fabbo-ai/fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator) - Claude Code / Codex skill that drives a real Playwright browser to generate AI videos and images on [fabbo.ai](https://fabbo.ai) across Veo, Sora, Kling, Wan, Luma, Runway, Midjourney, and Nano Banana.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Adds [fabbo-ai-generator](https://github.com/fabbo-ai/fabbo-ai-generator) to Phase 2 → Ready-to-Use Skill Libraries → Popular Collections. A cross-agent (Claude Code / Codex) SKILL.md package that drives a real Playwright browser session to generate AI videos and images on [fabbo.ai](https://fabbo.ai) across Veo, Sora, Kling, Wan, Luma, Runway, Midjourney, and Nano Banana.