### PR TITLE
Add MiniMax-AI/cli to Popular Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 
 #### Popular Collections
 
+- [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli) - Skills for text, image, video, speech, and music generation via the MiniMax AI platform.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the **Popular Collections** section under **Ready-to-Use Skill Libraries**
- The skill is discoverable and installable from the [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli) repository (`skill/` path)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 line changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard.

## Test plan

- Link is valid and points to the correct GitHub repository
- Entry follows existing format: `[Name](URL) - Description.`
- No duplicates introduced