### PR TITLE
Add fastxyz/skill-optimizer to Benchmarks and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Evaluation frameworks and deeper technical reading.
 - [huggingface/upskill](https://github.com/huggingface/upskill) - Library: Use Upskill to Generate and evaluate agent skills for code agents.
 - [benchflow-ai/SkillsBench](https://github.com/benchflow-ai/SkillsBench) - Library: Use Benchflow for Measuring skills performance on real workflows.
 - [Practical Guide to Evaluating and Testing Agent Skills](https://www.philschmid.de/testing-skills) - Blog: A guide for testing agent skills
+- [fastxyz/skill-optimizer](https://github.com/fastxyz/skill-optimizer) - Tool: CLI that benchmarks SKILL.md guidance docs against multiple LLMs and runs an iterative optimizer to rewrite them until every configured model meets a score floor.
 
 ### Advanced Engineering
 


### PR DESCRIPTION
skill-optimizer is a CLI tool that benchmarks your SKILL.md guidance docs against multiple LLMs using static action + argument matching. It measures whether each model calls the right tools with the right arguments, and runs an iterative optimizer that rewrites your SKILL.md until every configured model meets a score floor.

Fits under "Benchmarks and Evaluation" alongside huggingface/upskill and benchflow-ai/SkillsBench, filling the gap for iterative SKILL.md optimization driven by benchmark results.

Repo: https://github.com/fastxyz/skill-optimizer