### PR TITLE
Add OpenAccountants to Popular Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [openaccountants/openaccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries (VAT/GST, income tax, social contributions).
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Adds OpenAccountants to the Popular Collections section under Ready-to-Use Skill Libraries.

**What it does:** 371 tax classification skills across 134 countries — VAT/GST, income tax, and social contributions. Compatible with Claude Code, Cursor, Gemini CLI, and any LLM that accepts file-based context.

**Repository:** https://github.com/openaccountants/openaccountants