### PR TITLE
Add OpenHumancy skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [Skillstore](https://skillstore.io/) - Curated marketplace for Agent Skills.
 - [SkillsDirectory](https://www.skillsdirectory.org/) - Directory of popular Agent Skills.
 - [skills.sh](https://skills.sh/) - A directory and leaderboard for Agent Skills.
+- [OpenHumancy Skill](https://github.com/openhumancy/openhumancy-skill) — Delegate real-world tasks to human workers via TON-powered escrow platform.
 
 ## Phase 3: Build and Integrate
 


### PR DESCRIPTION
An [Agent Skill](https://github.com/anthropics/skills) that gives AI coding agents the ability to delegate real-world tasks to human workers via the [OpenHumancy](https://openhumancy.com/) platform.