### PR TITLE
Add unslop to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [LangChain Deep Agents](https://github.com/langchain-ai/deepagents) - Framework: Agent harness with a skills-oriented workflow.
 - [IntentKit](https://github.com/crestalnetwork/intentkit) - Framework: Intent-driven agent building.
 - [Agentica](https://github.com/wrtnlabs/agentica) - Framework: TypeScript function-calling utilities for agents.
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - Tool: CLI that strips AI writing patterns from skill descriptions, docs, and generated content via stdin pipe.
 
 ## Phase 4: Benchmarks and Research
 


### PR DESCRIPTION
Add unslop to Developer Tools section.

**Tool:** unslop — CLI that strips AI writing patterns from text via stdin pipe

**GitHub:** https://github.com/MohamedAbdallah-14/unslop

Useful for skill authors who want to ensure their SKILL.md descriptions and agent-generated content don't contain AI writing patterns before publishing. Pipe any text through it:

```bash
cat SKILL.md | unslop --stdin --deterministic
```

Fits under Developer Tools alongside SkillCheck and OpenSkills.