### PR TITLE
Add buyer-eval-skill to Popular Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - A structured B2B software vendor evaluation skill: domain-expert questions per software category, vendor AI agent conversations, evidence-tracked scoring across 7 dimensions, and comparative scorecards for procurement and build-vs-buy decisions.
 
 ### Skill Marketplaces & directories
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
-- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - A structured B2B software vendor evaluation skill: domain-expert questions per software category, vendor AI agent conversations, evidence-tracked scoring across 7 dimensions, and comparative scorecards for procurement and build-vs-buy decisions.
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring with evidence-tracked scorecards for procurement and build-vs-buy decisions.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
Adds [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) under **Phase 2: Use Existing Skills → Ready-to-Use Skill Libraries → Popular Collections**.

**What it is**: Structured, evidence-based B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions. Aimed at procurement, RFP evaluation, and build-vs-buy decisions.

**License**: MIT

**Install**:
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

Note: this is a single-purpose skill (not a multi-skill collection like the others in this section). If you'd prefer a different placement, happy to move it — let me know.