### PR TITLE
Add KubeStellar Console to Popular Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [kubestellar/console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with 10+ agent skills for performance testing, cache compliance, CI debugging, TDD, and K8s troubleshooting. Includes MCP server for bridging agents to Kubernetes APIs.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
## What
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Ready-to-Use Skill Libraries > Popular Collections** section.

## Why
KubeStellar Console (CNCF project) ships 10+ built-in agent skills for Kubernetes development:

- @perf-test, @cache-test, @nav-test, @ui-compliance-test
- @ci-status, @rca, @tdd, @k8s-debug
- @create-agentic-workflow, @debug-agentic-workflow

Its `kc-agent` MCP server bridges coding agents to kubeconfig and Kubernetes APIs. Compatible with Claude Code, Codex, and Gemini CLI via `CLAUDE.md` and `AGENTS.md`.

- **GitHub**: https://github.com/kubestellar/console
- **Website**: https://console.kubestellar.io