### PR TITLE
Add UIZZE UI design skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [samuelbushi/uizze](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - UI design grounding from 800,000+ real web and iOS screens, with a design contract and finish gate.
 
 ### Skill Marketplaces & directories
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
-- [samuelbushi/uizze](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - UI design grounding from 800,000+ real web and iOS screens, with a design contract and finish gate.
+- [samuelbushi/uizze](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - UI design grounding from 800,000+ real web and iOS screens, with a design contract and finish gate.
 
 ### Skill Marketplaces & directories
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
-- [samuelbushi/uizze](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - UI design grounding from 800,000+ real web and iOS screens, with a design contract and finish gate.
+- [uizze/uizze](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - UI design grounding from 800,000+ real web and iOS screens, with a design contract and finish gate.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
## What changed

Adds UIZZE to the ready-to-use skill libraries list.

UIZZE is a public `SKILL.md` workflow for Codex, Claude Code, Cursor, and compatible coding agents. It grounds UI work in 800,000+ real web and iOS screens, then asks the agent to use a design contract and finish gate before shipping.

## Validation

- Verified the linked public skill returns HTTP 200
- Kept the change to one factual README entry
