### PR TITLE
Add plasma-ai/wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Guides and tools for authoring, validating, and distributing skills.
 - [LangChain Deep Agents](https://github.com/langchain-ai/deepagents) - Framework: Agent harness with a skills-oriented workflow.
 - [IntentKit](https://github.com/crestalnetwork/intentkit) - Framework: Intent-driven agent building.
 - [Agentica](https://github.com/wrtnlabs/agentica) - Framework: TypeScript function-calling utilities for agents.
+- [plasma-ai/wiki](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) - Tool: Agent Skill and CLI for building and maintaining indexed Markdown knowledge bases.
 
 ## Phase 4: Benchmarks and Research
 


### PR DESCRIPTION
## Summary

Add the [plasma-ai/wiki skill](https://github.com/plasma-ai/wiki/tree/main/wiki/skills/wiki) to **Phase 3 → Developer Tools**.

wiki is directly related to the Agent Skills format: it ships an installable `SKILL.md` and a deterministic CLI for the knowledge-base workflow the skill describes. The skill uses progressive disclosure and keeps detailed command guidance in its body.

Disclosure: I'm affiliated with the project.