### PR TITLE
Add UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Platforms that support skills today, plus ready-to-use skill catalogs.
 - [muratcankoylan/Agent-Skills-for-Context-Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) - A collection of Agent Skills for context engineering (from Anthropic).
 - [Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs) - A collection of AI/ML research and engineering skills.
 - [phuryn/pm-skills](https://github.com/phuryn/pm-skills) - A collection of PM Skills
+- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - MIT Skill for preventing generic UI with design contracts and hard finish gates.
 
 ### Skill Marketplaces & directories
 


### PR DESCRIPTION
## Summary
- add the canonical UIZZE `anti-ui-slop` Skill to Popular Collections
- link directly to the maintained MIT `SKILL.md` source
- keep the description concise and focused on the Skill's actual workflow

## Verification
- `git diff --check`
- source: https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop
- install: `npx skills add https://uizze.com --skill anti-ui-slop`